### PR TITLE
Use KDE 6.8 runtime

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -1,6 +1,6 @@
 app-id: org.torproject.torbrowser-launcher
 runtime: org.kde.Platform
-runtime-version: 6.7
+runtime-version: 6.8
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
 base-version: 6.7

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -55,9 +55,9 @@ modules:
           project-id: 1239
           url-template: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2
     post-install:
-      - mv /app/lib/python3.11/site-packages/gpg-1.23.2-*.egg/gpg /app/lib/python3.11/site-packages/
-      - mv /app/lib/python3.11/site-packages/gpg-1.23.2-*.egg/EGG-INFO /app/lib/python3.11/site-packages/gpg-1.23.2-py3.10.egg-info
-      - rm -r /app/lib/python3.11/site-packages/gpg-1.23.2-*.egg
+      - mv /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg/gpg /app/lib/python3.13/site-packages/
+      - mv /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg/EGG-INFO /app/lib/python3.13/site-packages/gpg-1.23.2-py3.10.egg-info
+      - rm -r /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg
 
   - name: python3-requests
     buildsystem: simple

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -78,8 +78,8 @@ modules:
           type: pypi
           name: wheel
       - type: file
-        url: https://files.pythonhosted.org/packages/c4/e6/c1ac50fe3eebb38a155155711e6e864e254ce4b6e17fe2429b4c4d5b9e80/flit_core-3.9.0.tar.gz
-        sha256: 72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba
+        url: https://files.pythonhosted.org/packages/52/92/89cceb9c49f3e6c72091304636c5ebc2fc48c546742bbf8a6a474e48e666/flit_core-3.10.0.tar.gz
+        sha256: 6d904233178b3c924f665947ac7d286f2ac799fb69087e39e56ceb4084724a97
         x-checker-data:
           type: pypi
           name: flit_core

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -1,9 +1,9 @@
 app-id: org.torproject.torbrowser-launcher
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: 6.7
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: 5.15-23.08
+base-version: 6.7
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 build-options:

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -66,8 +66,8 @@ modules:
         requests
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/07/37/b31be7e4b9f13b59cde9dcaeff112d401d49e0dc5b37ed4a9fc8fb12f409/setuptools-75.2.0.tar.gz
-        sha256: 753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec
+        url: https://files.pythonhosted.org/packages/ed/22/a438e0caa4576f8c383fa4d35f1cc01655a46c75be358960d815bfbb12bd/setuptools-75.3.0.tar.gz
+        sha256: fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686
         x-checker-data:
           type: pypi
           name: setuptools

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -55,9 +55,9 @@ modules:
           project-id: 1239
           url-template: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2
     post-install:
-      - mv /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg/gpg /app/lib/python3.12/site-packages/
-      - mv /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg/EGG-INFO /app/lib/python3.12/site-packages/gpg-1.23.2-py3.10.egg-info
-      - rm -r /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg
+      - mv /app/lib/python3.12/site-packages/gpg-1.24.0-*.egg/gpg /app/lib/python3.12/site-packages/
+      - mv /app/lib/python3.12/site-packages/gpg-1.24.0-*.egg/EGG-INFO /app/lib/python3.12/site-packages/gpg-1.24.0-py3.10.egg-info
+      - rm -r /app/lib/python3.12/site-packages/gpg-1.24.0-*.egg
 
   - name: python3-requests
     buildsystem: simple

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -55,9 +55,9 @@ modules:
           project-id: 1239
           url-template: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2
     post-install:
-      - mv /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg/gpg /app/lib/python3.13/site-packages/
-      - mv /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg/EGG-INFO /app/lib/python3.13/site-packages/gpg-1.23.2-py3.10.egg-info
-      - rm -r /app/lib/python3.13/site-packages/gpg-1.23.2-*.egg
+      - mv /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg/gpg /app/lib/python3.12/site-packages/
+      - mv /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg/EGG-INFO /app/lib/python3.12/site-packages/gpg-1.23.2-py3.10.egg-info
+      - rm -r /app/lib/python3.12/site-packages/gpg-1.23.2-*.egg
 
   - name: python3-requests
     buildsystem: simple


### PR DESCRIPTION
As the new stable version of KDE Runtime is released. This PR updates the runtime to KDE 6.7. Also updates com.riverbankcomputing.PyQt.BaseApp to 6.7 too