### PR TITLE
Enable accessibility (a11y) support

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -22,6 +22,8 @@ finish-args:
   - --socket=pulseaudio
   - --env=GTK_USE_PORTAL=1
   - --env=MOZ_ENABLE_WAYLAND=1
+  - --talk-name=org.a11y.Bus
+  - --env=GNOME_ACCESSIBILITY=1
 modules:
   - shared-modules/dbus-glib/dbus-glib.json
 


### PR DESCRIPTION
E.g. for screen readers and such.

Although the GNOME_ACCESSIBILITY env var sounds Gnome specific it should work in any environment.