### PR TITLE
Temporary remove the pyparsing x-checker-data

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -163,10 +163,6 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
         sha256: 506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1
-        x-checker-data:
-          type: pypi
-          name: pyparsing
-          packagetype: bdist_wheel
 
   - name: python3-distro
     buildsystem: simple


### PR DESCRIPTION
Do not update this module until the incorrect shebang issue gets resolved.

See the following comment for more details: https://github.com/flathub/org.torproject.torbrowser-launcher/pull/103#issuecomment-2749551328