### PR TITLE
Re-add pyparsing x-checker-data, remove the setuptools one

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -70,9 +70,6 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/32/d2/7b171caf085ba0d40d8391f54e1c75a1cda9255f542becf84575cfd8a732/setuptools-76.0.0.tar.gz
         sha256: 43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4
-        x-checker-data:
-          type: pypi
-          name: setuptools
       - type: file
         url: https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz
         sha256: 661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729
@@ -163,6 +160,10 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl
         sha256: 506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1
+        x-checker-data:
+          type: pypi
+          name: pyparsing
+          packagetype: bdist_wheel
 
   - name: python3-distro
     buildsystem: simple


### PR DESCRIPTION
The incorrect shebang issue seems to be caused by newer setuptools.