### PR TITLE
Disable gpgme x-checker-data

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -52,10 +52,10 @@ modules:
       - type: archive
         url: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.24.3.tar.bz2
         sha256: bfc17f5bd1b178c8649fdd918956d277080f33df006a2dc40acdecdce68c50dd
-        x-checker-data:
-          type: anitya
-          project-id: 1239
-          url-template: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2
+      #  x-checker-data:
+      #    type: anitya
+      #    project-id: 1239
+      #    url-template: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$version.tar.bz2
     post-install:
       - mv /app/lib/python3.12/site-packages/gpg-1.24.3-*.egg/gpg /app/lib/python3.12/site-packages/
       - mv /app/lib/python3.12/site-packages/gpg-1.24.3-*.egg/EGG-INFO /app/lib/python3.12/site-packages/gpg-1.24.3-py3.10.egg-info


### PR DESCRIPTION
The newer version has incompatible changes. Disable the External Data Checker for now.