### PR TITLE
Drop redundancies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -24,8 +24,6 @@ finish-args:
   - --talk-name=org.a11y.Bus
   - --env=GNOME_ACCESSIBILITY=1
 modules:
-  - shared-modules/dbus-glib/dbus-glib.json
-
   - name: PyQtApp
 
   - name: SWIG

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -21,7 +21,6 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --env=GTK_USE_PORTAL=1
-  - --env=MOZ_ENABLE_WAYLAND=1
   - --talk-name=org.a11y.Bus
   - --env=GNOME_ACCESSIBILITY=1
 modules:
@@ -181,23 +180,6 @@ modules:
           type: pypi
           name: distro
           packagetype: bdist_wheel
-
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dman=false
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.6.tar.xz
-        sha256: c5540aaefb60e1d63b1c587c05f2284ebe72ece7d0c0e5e4a778cfd5844b6b58
-        x-checker-data:
-          type: anitya
-          project-id: 13149
-          url-template: https://download.gnome.org/sources/libnotify/$major.$minor/libnotify-$version.tar.xz
 
   - name: torbrowser-launcher
     buildsystem: simple


### PR DESCRIPTION
Wayland is already enforced by `--socket=fallback-x11` which removes x11 socket on wayland leaving no choice for the app

libnotify is part of runtime since 24.08

I have to say that enforcing wayland here is highly controversial when upstream disabled it until they can assess its fingerprint impact