### PR TITLE
Dont allow org.a11y.bus

### DIFF
--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --socket=fallback-x11
   - --device=dri
   - --socket=pulseaudio
+  - --env=GNOME_ACCESSIBILITY=1
   - --env=GTK_USE_PORTAL=1
 modules:
   - name: SWIG

--- a/org.torproject.torbrowser-launcher.yaml
+++ b/org.torproject.torbrowser-launcher.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --env=GTK_USE_PORTAL=1
-  - --talk-name=org.a11y.Bus
 modules:
   - name: SWIG
     config-opts:


### PR DESCRIPTION
So it seems adding `org.a11y.bus=talk` in [pull request 97](https://github.com/flathub/org.torproject.torbrowser-launcher/pull/97) was a mistake, accessibility works fine without it, but the `GNOME_ACCESSIBILITY=1` part was actually needed. Sorry for not noticing when you asked about dropping it in [pull request 150](https://github.com/flathub/org.torproject.torbrowser-launcher/pull/150)!

With these changes the sandbox should be tighter, and accessibility support should work out-of-the-box in more environments.